### PR TITLE
Add validators to prevent empty strings or all spaces

### DIFF
--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -29,7 +29,10 @@ def _modify_user_schema(context, mode):
 
     # add required schema fields with not_empty validator
     for field in advancedauth_schema_keys["required"]:
-        schema[field] = [get_validators()["not_empty_string"], toolkit.get_validator("not_empty")]
+        schema[field] = [
+            get_validators()["not_empty_string"],
+            toolkit.get_validator("not_empty"),
+        ]
 
     # add optionals schema fields with ignore_missing validator
     for field in advancedauth_schema_keys["optional"]:
@@ -58,7 +61,10 @@ def custom_user_create(context, data_dict):
         return user_create(context, data_dict)
 
     schema = context["schema"]
-    schema["email"] += [get_validators()["not_empty_string"], toolkit.get_validator("email_validator")]
+    schema["email"] += [
+        get_validators()["not_empty_string"],
+        toolkit.get_validator("email_validator"),
+    ]
 
     context = _modify_user_schema(context, "create")
     data_dict["email"] = data_dict["email"].lower()
@@ -186,7 +192,10 @@ def custom_user_show(context, data_dict):
 # edits custom metadata in update function
 def custom_user_update(context, data_dict):
     schema = context["schema"]
-    schema["email"] += [get_validators()["not_empty_string"], toolkit.get_validator("email_validator")]
+    schema["email"] += [
+        get_validators()["not_empty_string"],
+        toolkit.get_validator("email_validator"),
+    ]
 
     # ignore this onpassword reset workflow
     if context["auth_user_obj"] is not None:

--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -12,6 +12,7 @@ from ckan.model import core
 
 from .helpers import helpers
 from .model import advancedauthExtras
+from .validators import get_validators
 
 
 # injects validators from json schema into existing schema
@@ -28,7 +29,7 @@ def _modify_user_schema(context, mode):
 
     # add required schema fields with not_empty validator
     for field in advancedauth_schema_keys["required"]:
-        schema[field] = [toolkit.get_validator("not_empty")]
+        schema[field] = [get_validators()["not_empty_string"], toolkit.get_validator("not_empty")]
 
     # add optionals schema fields with ignore_missing validator
     for field in advancedauth_schema_keys["optional"]:
@@ -55,6 +56,9 @@ def custom_user_create(context, data_dict):
     if context.get("ignore_auth"):
         # Allow CKAN CLI to create sysadmin
         return user_create(context, data_dict)
+
+    schema = context["schema"]
+    schema["email"] += [get_validators()["not_empty_string"], toolkit.get_validator("email_validator")]
 
     context = _modify_user_schema(context, "create")
     data_dict["email"] = data_dict["email"].lower()
@@ -181,6 +185,9 @@ def custom_user_show(context, data_dict):
 
 # edits custom metadata in update function
 def custom_user_update(context, data_dict):
+    schema = context["schema"]
+    schema["email"] += [get_validators()["not_empty_string"], toolkit.get_validator("email_validator")]
+
     # ignore this onpassword reset workflow
     if context["auth_user_obj"] is not None:
         context = _modify_user_schema(context, "update")

--- a/ckanext/advancedauth/validators.py
+++ b/ckanext/advancedauth/validators.py
@@ -1,0 +1,14 @@
+from ckan.plugins.toolkit import Invalid
+
+# Raise error if uploaded file does not include an extension, or the extension is not allowed.
+def not_empty_string(key, flattened_data, errors, context):
+    value = flattened_data[key]
+    if value.strip() == "":
+        raise Invalid("Field cannot be blank or consist of only spaces.")
+
+
+# published to the plugin
+def get_validators():
+    return {
+        "not_empty_string": not_empty_string,
+    }

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -88,6 +88,9 @@ ckanext.advancedauth.user_create_email_recipient_email = admin@email.com
 ckanext.advancedauth.user_create_email_recipient_name = Admin
 ```
 
+### Validation
+The current iteration of CKAN (`2.9.3`) does not provide validation in the event of a user's email consisting of only whitespace (" "). This feature intercepts the CKAN action when a user registers or resets their password and adds the custom `not_empty_string` validator in addition to the CKAN `email_validator`. This plugin also adds the `not_empty_string` validator to any custom schema fields that have `required` set to `true`.
+
 ### Terms of Service / Privacy Policy
 
 Add a terms of service/data use agreement to your registration page. By enabling this option and providing a terms of service, users will be required to agree to a terms of service on the registration form.


### PR DESCRIPTION
This adds the new `not_empty_string` validator, which checks for an empty string after stripping any whitespace, to all required user fields. Also adding that same validator and the `email_validator` to `email` which seems to be erroneously missing from here: https://github.com/ckan/ckan/blob/f6c7e94dd95f7feb38b2f1518c4e442703eecafb/ckan/logic/schema.py#L423