### PR TITLE
Auth merge bugfix

### DIFF
--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -74,7 +74,6 @@ def only_approved_users(context, data_dict=None):
     orgs = func({}, {"id": user_id})
     if len(orgs):
         return {"success": True}
-    print(orgs)
     approval_message = toolkit.config.get(
         "ckanext.advancedauth.only_approved_users_message",
         "Your account is pending approval",

--- a/ckanext/advancedauth/plugin.py
+++ b/ckanext/advancedauth/plugin.py
@@ -1,7 +1,7 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
-from .auth import get_actions_list, get_auth_functions
+from .auth import get_actions_list
 from .helpers import helpers
 from .logic import actions
 from .model import initdb
@@ -35,11 +35,6 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     # Adds additional authentication functions to actions
     def get_auth_functions(self):
         return get_actions_list()
-
-    # IAuthFunctions
-    # Defines custom authentication gates
-    def get_auth_functions(self):
-        return get_auth_functions()
 
     # ITemplateHelpers
     # makes functions available in templates


### PR DESCRIPTION
Fixing the bugs created in the last MR.

The problem we encountered is that originally, our two different types of auth functions were in two different packages, and the advancedauth function was chainable. So first CKAN would check the advancedauth permission, then it would check the mecfs permission. It seems like based on the [IAuthFunctions docs](https://docs.ckan.org/en/latest/extensions/plugin-interfaces.html#ckan.plugins.interfaces.IAuthFunctions) you can't submit a list of permissions, so my solution here is to create a wrapper function that steps through the permission functions based on the config file. Because we need this function to be chainable, I had to refactor these to abort rather than return false as well.

So now, for every action in the system, this permission will be applied. It follows this workflow:

* run the auditor (which I'll have some more thoughts on later)
* check if `only_approved_users` is enabled and eligible and run it (which aborts on fail)
* check if `disallow_public_access` is enabled and eligible and run it (which aborts on fail)
* check if `only_authors_can_edit` is enabled and eligible and run it (which aborts on fail)
* return the next function in the chain
