### PR TITLE
switching the order of auth functions

### DIFF
--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -90,6 +90,19 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # get function name
     func_name = next_func.__name__
 
+    ## setup variables for disallow_anonymous_access
+    disallow_anonymous_access = toolkit.asbool(
+        toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access", False)
+    )
+
+    action_allowlist = toolkit.aslist(
+        toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
+    )
+
+    ## run advancedauth_check_access
+    if disallow_anonymous_access and func_name not in action_allowlist:
+        advancedauth_check_access(next_func, context, data_dict)
+
     # set up variables for only_approved_users
     only_approved_users_var = toolkit.asbool(
         toolkit.config.get("ckanext.advancedauth.only_approved_users", False)
@@ -106,19 +119,6 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     if only_approved_users_var and func_name in only_approved_users_actions:
 
         only_approved_users(context, data_dict)
-
-    ## setup variables for disallow_anonymous_access
-    disallow_anonymous_access = toolkit.asbool(
-        toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access", False)
-    )
-
-    action_allowlist = toolkit.aslist(
-        toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
-    )
-
-    ## run advancedauth_check_access
-    if disallow_anonymous_access and func_name not in action_allowlist:
-        advancedauth_check_access(next_func, context, data_dict)
 
     ## setup only_authors_can_edit
     only_authors_can_edit = toolkit.asbool(


### PR DESCRIPTION
Found an error locally - I was running `only_approved_users` before `advancedauth_check_access`, where the former does not work for logged-out users and the latter does. I swapped the order so that there is no longer any internal server error from `only_approved_users` checking for an authenticated user when you're not logged in.