### PR TITLE
Allow users to add form input classes from schema

### DIFF
--- a/ckanext/advancedauth/templates/user/new_user_form.html
+++ b/ckanext/advancedauth/templates/user/new_user_form.html
@@ -16,11 +16,11 @@
     {% set key = item[0] %}
     {% set value = item[1] %}
     {% if value.get('input', '') == 'text' %}
-      {{ form.input(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=data[key], error=errors[key], classes=["control-medium"], is_required=value.get('required', False)) }}
+      {{ form.input(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=data[key], error=errors[key], classes=["control-medium " + value.get('form_classes', '')], is_required=value.get('required', False)) }}
     {% elif value.get('input', '') == 'textarea' %}
-      {{ form.textarea(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=data[key], error=errors[key], classes=["control-medium"], is_required=value.get('required', False)) }}
+      {{ form.textarea(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=data[key], error=errors[key], classes=["control-medium " + value.get('form_classes', '')], is_required=value.get('required', False)) }}
     {% elif value.get('input', '') == 'checkbox' %}
-      {{ form.checkbox(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=True, checked=data[key], error=errors[key], classes=["control-medium"], is_required=value.get('required', False)) }}
+      {{ form.checkbox(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=True, checked=data[key], error=errors[key], classes=["control-medium " + value.get('form_classes', '')], is_required=value.get('required', False)) }}
     {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
This PR allows developers to add additional classes to the base class of `control-medium`. This is done by adding the key `form_classes` to the related field in their advancedauth schema. The value of `form_classes` should be a space-separated string of the classes that should be added.

Example:
```
"city": {
        "label": "City",
        "input": "text",
        "placeholder": "",
        "required": false,
        "private": true,
        "order": 1,
        "form_classes": "city-label",
    }
```