### PR TITLE
Check if schema key exists before getting/setting

### DIFF
--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -191,11 +191,12 @@ def custom_user_show(context, data_dict):
 
 # edits custom metadata in update function
 def custom_user_update(context, data_dict):
-    schema = context["schema"]
-    schema["email"] += [
-        get_validators()["not_empty_string"],
-        toolkit.get_validator("email_validator"),
-    ]
+    schema = context.get("schema")
+    if schema is not None:
+        schema["email"] += [
+            get_validators()["not_empty_string"],
+            toolkit.get_validator("email_validator"),
+        ]
 
     # ignore this onpassword reset workflow
     if context["auth_user_obj"] is not None:


### PR DESCRIPTION
Bug:
```
2021-10-19 13:33:19,609 ERROR [ckan.config.middleware.flask_app:524] 'schema'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.8/dist-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/flask/views.py", line 163, in dispatch_request
    return meth(*args, **kwargs)
  File "/srv/app/src/ckan/ckan/config/middleware/../../views/user.py", line 735, in post
    logic.get_action(u'user_update')(context, user_dict)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 477, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/local/lib/python3.8/dist-packages/ckanext/advancedauth/logic.py", line 194, in custom_user_update
    schema = context["schema"]
KeyError: 'schema'
```