### PR TITLE
Validator error bugfix

### DIFF
--- a/ckanext/advancedauth/templates/user/edit_user_form.html
+++ b/ckanext/advancedauth/templates/user/edit_user_form.html
@@ -31,6 +31,21 @@
         {{ form.textarea(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=data[key], error=errors[key], classes=["control-medium"], is_required=value.get('required', False)) }}
       {% elif value.get('input', '') == 'checkbox' %}
         {{ form.checkbox(key, id="field-" + key, label=_(value.get('label', '')), placeholder=_(value.get('placeholder', '')), value=True, checked=data[key], error=errors[key], classes=["control-medium"], is_required=value.get('required', False)) }}
+      {% elif value.get('input', '') == 'select' %}
+        <div class="form-group control-medium mb-0">
+          <label for="field-{{ key }}">
+            {% if value.get('required', False) %} <span title="This field is required" class="control-required">*</span> {% endif %} {{ value.get('label', '') }}
+          </label>
+          <div class="controls">
+            <select name="{{ key }}" id="field-{{ key }}" class="form-control">
+              {% for option in value.get('choices', []) %}
+                <option value="{{ option.get('value', '') }}" {% if option.get('value', '') == data[key] %} selected {% endif %} {% if value.get('required', False) %} required {% endif %} >
+                  {{ option.get('label', '') }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
       {% endif %}
     {% endfor %}
 

--- a/ckanext/advancedauth/validators.py
+++ b/ckanext/advancedauth/validators.py
@@ -3,7 +3,7 @@ from ckan.plugins.toolkit import Invalid
 # Raise error if uploaded file does not include an extension, or the extension is not allowed.
 def not_empty_string(key, flattened_data, errors, context):
     value = flattened_data.get(key, "")
-    if value.strip() == "":
+    if not value or value.strip() == "":
         raise Invalid("Field cannot be blank or consist of only spaces.")
 
 


### PR DESCRIPTION
This MR fixes [MECFSDEV-1609](https://jira.rti.org/browse/MECFSDEV-1609). Recently we added functionality to allow selects as a new schema type on the user form, but it was only added to the registration template and not the edit template. This meant that attempting to edit a user would be missing a key rather than sending that value as null or a blank string. This MR adds two fixes:

* Adds the select option to the edit template
* adds an `if not value` statement as well so that validation fails (rather than have an unhandled exception) in the case of a completely missing key instead of a blank string.