### PR TITLE
MECFSDEV-1665 non admin users should only be able to create private datasets

### DIFF
--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -6,6 +6,7 @@ from .model import advancedauthAudit
 
 log = logging.getLogger(__name__)
 
+
 # writes an audit object to the audit table
 def advancedauth_auditor(next_func, context, data_dict=None):
     func_name = next_func.__name__
@@ -125,7 +126,7 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     )
     only_approved_users_actions = [
         "package_show",
-        "user_list", # integration tool checks user_list access 
+        "user_list",  # integration tool checks user_list access
         "user_show",
         "organization_list",
     ]
@@ -133,7 +134,6 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # run only_approved_users
     # this aborts with 403 if failed
     if only_approved_users_var and func_name in only_approved_users_actions:
-
         only_approved_users(context, data_dict)
 
     ## setup only_authors_can_edit

--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -2,7 +2,9 @@ import datetime
 
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.mailer as mailer
-
+import ckan.model as model
+from ckan.plugins.toolkit import chained_action
+from ckan.logic import ValidationError
 from ckan.logic.action.create import user_create
 from ckan.logic.action.get import user_show
 from ckan.logic.action.update import user_update
@@ -55,7 +57,6 @@ def _modify_user_schema(context, mode):
 
 # intercepts user creation and gathers new data
 def custom_user_create(context, data_dict):
-
     if context.get("ignore_auth"):
         # Allow CKAN CLI to create sysadmin
         return user_create(context, data_dict)
@@ -288,6 +289,31 @@ def custom_user_delete(context, data_dict):
     model.repo.commit()
 
 
+# Sysadmins have access to the original package functions
+# Non-admin users have restrictions on dataset visibility
+def enforce_visibility_check(func_name):
+    # CKAN chained_action decorator requires function to be named the same as original
+    # https://docs.ckan.org/en/2.9/extensions/plugin-interfaces.html#ckan.plugins.interfaces.IActions
+    @chained_action
+    def func(original_action, context, data_dict):
+        try:
+            toolkit.check_access("sysadmin", context, {})
+        except toolkit.NotAuthorized:
+            try:
+                # only sysadmins can change visibility on existing datasets
+                pkg = toolkit.get_action("package_show")(
+                    {"ignore_auth": True}, {"id": data_dict.get("name")}
+                )
+                data_dict["private"] = pkg["private"]
+            except ValidationError:
+                # only sysadmins can make public datasets
+                data_dict["private"] = True
+        return original_action(context, data_dict)
+
+    func.__name__ = func_name
+    return func
+
+
 # returns our new custom actions overriding the basic action names, and returns the framework actions as ckan_<action> for compatibility if needed
 actions = {
     "user_create": custom_user_create,
@@ -298,4 +324,7 @@ actions = {
     "ckan_user_show": user_show,
     "ckan_user_create": user_create,
     "ckan_user_delete": user_delete,
+    "package_create": enforce_visibility_check("package_create"),
+    "package_update": enforce_visibility_check("package_update"),
+    "package_revise": enforce_visibility_check("package_revise"),
 }

--- a/ckanext/advancedauth/validators.py
+++ b/ckanext/advancedauth/validators.py
@@ -1,5 +1,6 @@
 from ckan.plugins.toolkit import Invalid
 
+
 # Raise error if uploaded file does not include an extension, or the extension is not allowed.
 def not_empty_string(key, flattened_data, errors, context):
     value = flattened_data.get(key, "")


### PR DESCRIPTION
PR introduces logic that handles dataset visibility settings based on sysadmin status.

**For Non-Admin Users:**
- **Creating a New Dataset**: If a non-admin user creates a dataset, the visibility is automatically set to private, regardless of any visibility setting the user might choose.
- **Modifying an Existing Dataset**: If a non-admin user attempts to change the visibility of an existing dataset, this change is ignored, and the existing private value is retained. Other edits to the package are allowed as usual.

**For Admin Users:**
- No changes. Package actions perform the same as before.