### PR TITLE
Include sysadmins in audit explorer

### DIFF
--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -3,7 +3,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/advancedauth/auditdata.py
+++ b/ckanext/advancedauth/auditdata.py
@@ -1,12 +1,5 @@
 from ckan.common import request
 import ckan.plugins.toolkit as toolkit
-from ckan.logic.action.get import (
-    user_show,
-    user_list,
-    current_package_list_with_resources,
-    resource_show,
-    package_show,
-)
 import ckan.model as model
 from ckan.logic import NotFound, ValidationError
 from flask import Blueprint
@@ -66,7 +59,7 @@ def date_audit():
 @audit_table.route("/getusers")
 def list_users():
     if toolkit.g.userobj and toolkit.g.userobj.sysadmin:
-        users = user_list({"model": model}, {})
+        users = toolkit.get_action("user_list")(data_dict={})
         return {user["id"]: {k: v for k, v in user.items()} for user in users}
     return {
         "error": "User must be logged in as a sysadmin in order to access this API endpoint."
@@ -76,8 +69,8 @@ def list_users():
 @audit_table.route("/getresources")
 def list_resources():
     if toolkit.g.userobj and toolkit.g.userobj.sysadmin:
-        packages = current_package_list_with_resources(
-            {"user": toolkit.g.userobj.name, "model": model}, {}
+        packages = toolkit.get_action("current_package_list_with_resources")(
+            data_dict={}
         )
         resource_lst = []
         for package in packages:
@@ -97,17 +90,23 @@ def map_row_data(row):
     resource_name = ""
     package_name = ""
     try:
-        resource_name = resource_show({"model": model}, {"id": row.resource_id})["name"]
+        resource_name = toolkit.get_action("resource_show")(
+            data_dict={"id": row.resource_id}
+        )["name"]
     except (NotFound, ValidationError):
         resource_name = ""
     try:
-        package_name = package_show({"model": model}, {"id": row.package_id})["name"]
+        package_name = toolkit.get_action("package_show")(
+            data_dict={"id": row.package_id}
+        )["name"]
     except (NotFound, ValidationError):
         package_name = ""
     return {
         "id": row.id,
         "user_id": row.user_id,
-        "username": user_show({"model": model}, {"id": row.user_id})["name"],
+        "username": toolkit.get_action("user_show")(data_dict={"id": row.user_id})[
+            "name"
+        ],
         "action": row.action,
         "package_id": row.package_id,
         "package_name": package_name,

--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -113,7 +113,6 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # get function name
     func_name = next_func.__name__
 
-
     ## setup variables for disallow_anonymous_access
     disallow_anonymous_access = toolkit.asbool(
         toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access") or False
@@ -126,9 +125,9 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     ## run advancedauth_check_access
     if disallow_anonymous_access and func_name not in action_allowlist:
         advancedauth_check_access(next_func, context, data_dict)
-    
+
     # if user is sysadmin, skip all checks
-    username = context.get('user', "")
+    username = context.get("user", "")
     user = _get_user(username)
     if user:
         if user.is_deleted():
@@ -173,6 +172,7 @@ def get_actions_list():
     for action in actions:
         actions_list[action] = advancedauth_wrapper_function
     return actions_list
+
 
 def _get_user(username):
     if not username:

--- a/ckanext/advancedauth/tests/test_plugin.py
+++ b/ckanext/advancedauth/tests/test_plugin.py
@@ -1,4 +1,5 @@
 """Tests for plugin.py."""
+
 import pytest
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic


### PR DESCRIPTION
PR adds the `@auth_sysadmins_check` decorator as mentioned in the mecfs dev channel by Alex. Sysadmin audit objects are now able to be added to the audit table.