### PR TITLE
New user registration changes

### DIFF
--- a/ckanext/advancedauth/templates/user/new_user_form.html
+++ b/ckanext/advancedauth/templates/user/new_user_form.html
@@ -118,6 +118,16 @@
   </div>
 </form>
 
+<script type="text/javascript">
+  var errors = document.querySelectorAll('.error-explanation li');
+  errors.forEach(function(error) {
+    // replace 'Password1:' and 'Password2:' with 'Password:'
+    var text = error.textContent;
+    text = text.replace("Password1:", "Password:").replace("Password2:", "Password:");
+    error.textContent = text;
+  });
+</script>
+
 {% if h.advancedauth_must_view_terms_of_service() %}
 <script type="text/javascript">
   let dua_viewed = document.getElementById('field-advancedauth_terms_of_service')

--- a/ckanext/advancedauth/templates/user/new_user_form.html
+++ b/ckanext/advancedauth/templates/user/new_user_form.html
@@ -7,6 +7,10 @@
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("First and Last Name"), value=data.fullname, error=errors.fullname, classes=["control-medium"], is_required=fullname_req) }}
 
   {{ form.input("email", id="field-email", label=_("Email (Institutional Email Preferred)"), type="email", placeholder=_("email@yourinstitution.org"), value=data.email, error=errors.email, classes=["control-medium"], is_required=True) }}
+      <!-- Helper text for the password field -->
+  <p id="password-help" class="form-text">
+    {{ _("Your password must be at least ten characters and include at least three of the following types of characters: capital letters, lower case letters, digits and special characters.") }}
+  </p>
   {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], is_required=True) }}
   {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password2, classes=["control-medium"], is_required=True) }}
 


### PR DESCRIPTION
PR adds UI changes to the new user registration form:
- Rename "Password1" and "Password2" to Password
- Add password helper text

![Screenshot 2024-02-02 at 12 22 49 PM](https://github.com/RTIInternational/ckanext-advancedauth/assets/108894496/1e5775e5-23a9-4ab9-8e9c-3d1269332d16)

![Screenshot 2024-02-02 at 12 37 25 PM](https://github.com/RTIInternational/ckanext-advancedauth/assets/108894496/cab464c8-da9d-4732-80d9-ba867dcb1783)

