### PR TITLE
MECFSDEV-1750 require password reset for all users feature

### DIFF
--- a/ckanext/advancedauth/blueprint.py
+++ b/ckanext/advancedauth/blueprint.py
@@ -107,7 +107,7 @@ class ExtendedEditView(EditView):
             error_summary = e.error_summary
             return self.get(id, data_dict, errors, error_summary)
 
-        h.flash_success(_(u'Profile updated'))
+        h.flash_success(_(u'Password updated'))
         ae.update_password_date(data_dict["id"], "password_last_reset_date")
         resp = h.redirect_to(u'user.read', id=user[u'name'])
         return resp

--- a/ckanext/advancedauth/blueprint.py
+++ b/ckanext/advancedauth/blueprint.py
@@ -1,0 +1,150 @@
+import ckan.lib.base as base
+import ckan.lib.helpers as h
+import ckan.lib.mailer as mailer
+import ckan.lib.navl.dictization_functions as dictization_functions
+import ckan.logic as logic
+import ckan.model as model
+import ckan.lib.authenticator as authenticator
+
+from ckan.common import _, g, request
+from ckan.views.user import PerformResetView, EditView
+from .model import advancedauthExtras as ae
+from six import text_type
+from flask import Blueprint, request
+
+import logging
+
+log = logging.getLogger(__name__)
+
+advancedauth_user = Blueprint("advancedauth_user", __name__, url_prefix="/user")
+
+
+class ExtendedPerformResetView(PerformResetView):
+    # This is a copy of the PerformResetView post method from ckan/views/user.py
+    # Adds update_password_date and changes validation error dict to error_summary
+    def post(self, id):
+        context, user_dict = self._prepare(id)
+        context["reset_password"] = True
+        user_state = user_dict["state"]
+        error_summary = None
+        try:
+            new_password = self._get_form_password()
+            user_dict["password"] = new_password
+            username = request.form.get("name")
+            if username is not None and username != "":
+                user_dict["name"] = username
+            user_dict["reset_key"] = g.reset_key
+            user_dict["state"] = model.State.ACTIVE
+            logic.get_action("user_update")(context, user_dict)
+            mailer.create_reset_key(context["user_obj"])
+            ae.update_password_date(user_dict["id"], "password_last_reset_date")
+            h.flash_success(_("Your password has been reset."))
+            return h.redirect_to("home.index")
+        except logic.NotAuthorized:
+            h.flash_error(_("Unauthorized to edit user %s") % id)
+        except logic.NotFound:
+            h.flash_error(_("User not found"))
+        except dictization_functions.DataError:
+            h.flash_error(_("Integrity Error"))
+        except logic.ValidationError as e:
+            error_summary = e.error_summary
+        except ValueError as e:
+            error_summary = text_type(e)
+        user_dict["state"] = user_state
+        extra_vars = {"user_dict": user_dict, "error_summary": error_summary}
+        return base.render("user/perform_reset.html", extra_vars)
+
+
+class ExtendedEditView(EditView):
+    # This is a copy of the EditView post method from ckan/views/user.py reused for required_reset page
+    # Adds update_password_date
+    def post(self, id=None):
+        context, id = self._prepare(id)
+        if not context[u'save']:
+            return self.get(id)
+
+        try:
+            data_dict = logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(request.form))))
+            data_dict.update(logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(request.files))))
+            )
+
+        except dictization_functions.DataError:
+            base.abort(400, _(u'Integrity Error'))
+        data_dict.setdefault(u'activity_streams_email_notifications', False)
+
+        context[u'message'] = data_dict.get(u'log_message', u'')
+        data_dict[u'id'] = id
+
+        if (data_dict[u'password1']
+                and data_dict[u'password2']):
+            identity = {
+                u'login': g.user,
+                u'password': data_dict[u'old_password']
+            }
+            auth = authenticator.UsernamePasswordAuthenticator()
+
+            if auth.authenticate(request.environ, identity) != g.user:
+                errors = {
+                    u'oldpassword': [_(u'Password entered was incorrect')]
+                }
+                error_summary = {_(u'Old Password'): _(u'incorrect password')}\
+                    if not g.userobj.sysadmin \
+                    else {_(u'Sysadmin Password'): _(u'incorrect password')}
+                return self.get(id, data_dict, errors, error_summary)
+
+        try:
+            user = logic.get_action(u'ckan_user_update')(context, data_dict)
+        except logic.NotAuthorized:
+            base.abort(403, _(u'Unauthorized to edit user %s') % id)
+        except logic.NotFound:
+            base.abort(404, _(u'User not found'))
+        except logic.ValidationError as e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+            return self.get(id, data_dict, errors, error_summary)
+
+        h.flash_success(_(u'Profile updated'))
+        ae.update_password_date(data_dict["id"], "password_last_reset_date")
+        resp = h.redirect_to(u'user.read', id=user[u'name'])
+        return resp
+
+    def get(self, id=None, data=None, errors=None, error_summary=None):
+        context, id = self._prepare(id)
+        data_dict = {u'id': id}
+
+        current_user = context.get(u'auth_user_obj').id
+        if current_user != id:
+            base.abort(403, _(u'Unauthorized to edit user %s') % u'')
+            
+        try:
+            old_data = logic.get_action(u'user_show')(context, data_dict)
+
+            g.display_name = old_data.get(u'display_name')
+            g.user_name = old_data.get(u'name')
+
+            data = data or old_data
+
+        except logic.NotAuthorized:
+            base.abort(403, _(u'Unauthorized to edit user %s') % u'')
+        except logic.NotFound:
+            base.abort(404, _(u'User not found'))
+
+
+        errors = errors or {}
+        extra_vars = {
+            u'data': data,
+            u'errors': errors,
+            u'error_summary': error_summary
+        }
+
+        return base.render(u'user/required_reset.html', extra_vars)
+
+
+advancedauth_user.add_url_rule(
+    "/reset/<id>", view_func=ExtendedPerformResetView.as_view(str("perform_reset"))
+)
+advancedauth_user.add_url_rule("/required_reset/<id>", view_func=ExtendedEditView.as_view(str("required_reset")))

--- a/ckanext/advancedauth/blueprint.py
+++ b/ckanext/advancedauth/blueprint.py
@@ -60,91 +60,89 @@ class ExtendedEditView(EditView):
     # Adds update_password_date
     def post(self, id=None):
         context, id = self._prepare(id)
-        if not context[u'save']:
+        if not context["save"]:
             return self.get(id)
 
         try:
             data_dict = logic.clean_dict(
                 dictization_functions.unflatten(
-                    logic.tuplize_dict(logic.parse_params(request.form))))
-            data_dict.update(logic.clean_dict(
-                dictization_functions.unflatten(
-                    logic.tuplize_dict(logic.parse_params(request.files))))
+                    logic.tuplize_dict(logic.parse_params(request.form))
+                )
+            )
+            data_dict.update(
+                logic.clean_dict(
+                    dictization_functions.unflatten(
+                        logic.tuplize_dict(logic.parse_params(request.files))
+                    )
+                )
             )
 
         except dictization_functions.DataError:
-            base.abort(400, _(u'Integrity Error'))
-        data_dict.setdefault(u'activity_streams_email_notifications', False)
+            base.abort(400, _("Integrity Error"))
+        data_dict.setdefault("activity_streams_email_notifications", False)
 
-        context[u'message'] = data_dict.get(u'log_message', u'')
-        data_dict[u'id'] = id
+        context["message"] = data_dict.get("log_message", "")
+        data_dict["id"] = id
 
-        if (data_dict[u'password1']
-                and data_dict[u'password2']):
-            identity = {
-                u'login': g.user,
-                u'password': data_dict[u'old_password']
-            }
+        if data_dict["password1"] and data_dict["password2"]:
+            identity = {"login": g.user, "password": data_dict["old_password"]}
             auth = authenticator.UsernamePasswordAuthenticator()
 
             if auth.authenticate(request.environ, identity) != g.user:
-                errors = {
-                    u'oldpassword': [_(u'Password entered was incorrect')]
-                }
-                error_summary = {_(u'Old Password'): _(u'incorrect password')}\
-                    if not g.userobj.sysadmin \
-                    else {_(u'Sysadmin Password'): _(u'incorrect password')}
+                errors = {"oldpassword": [_("Password entered was incorrect")]}
+                error_summary = (
+                    {_("Old Password"): _("incorrect password")}
+                    if not g.userobj.sysadmin
+                    else {_("Sysadmin Password"): _("incorrect password")}
+                )
                 return self.get(id, data_dict, errors, error_summary)
 
         try:
-            user = logic.get_action(u'ckan_user_update')(context, data_dict)
+            user = logic.get_action("ckan_user_update")(context, data_dict)
         except logic.NotAuthorized:
-            base.abort(403, _(u'Unauthorized to edit user %s') % id)
+            base.abort(403, _("Unauthorized to edit user %s") % id)
         except logic.NotFound:
-            base.abort(404, _(u'User not found'))
+            base.abort(404, _("User not found"))
         except logic.ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.get(id, data_dict, errors, error_summary)
 
-        h.flash_success(_(u'Password updated'))
+        h.flash_success(_("Password updated"))
         ae.update_password_date(data_dict["id"], "password_last_reset_date")
-        resp = h.redirect_to(u'user.read', id=user[u'name'])
+        resp = h.redirect_to("user.read", id=user["name"])
         return resp
 
     def get(self, id=None, data=None, errors=None, error_summary=None):
         context, id = self._prepare(id)
-        data_dict = {u'id': id}
+        data_dict = {"id": id}
 
-        current_user = context.get(u'auth_user_obj').id
+        current_user = context.get("auth_user_obj").id
         if current_user != id:
-            base.abort(403, _(u'Unauthorized to edit user %s') % u'')
-            
-        try:
-            old_data = logic.get_action(u'user_show')(context, data_dict)
+            base.abort(403, _("Unauthorized to edit user %s") % "")
 
-            g.display_name = old_data.get(u'display_name')
-            g.user_name = old_data.get(u'name')
+        try:
+            old_data = logic.get_action("user_show")(context, data_dict)
+
+            g.display_name = old_data.get("display_name")
+            g.user_name = old_data.get("name")
 
             data = data or old_data
 
         except logic.NotAuthorized:
-            base.abort(403, _(u'Unauthorized to edit user %s') % u'')
+            base.abort(403, _("Unauthorized to edit user %s") % "")
         except logic.NotFound:
-            base.abort(404, _(u'User not found'))
-
+            base.abort(404, _("User not found"))
 
         errors = errors or {}
-        extra_vars = {
-            u'data': data,
-            u'errors': errors,
-            u'error_summary': error_summary
-        }
+        extra_vars = {"data": data, "errors": errors, "error_summary": error_summary}
 
-        return base.render(u'user/required_reset.html', extra_vars)
+        return base.render("user/required_reset.html", extra_vars)
 
 
 advancedauth_user.add_url_rule(
     "/reset/<id>", view_func=ExtendedPerformResetView.as_view(str("perform_reset"))
 )
-advancedauth_user.add_url_rule("/required_reset/<id>", view_func=ExtendedEditView.as_view(str("required_reset")))
+advancedauth_user.add_url_rule(
+    "/required_reset/<id>", view_func=ExtendedEditView.as_view(str("required_reset"))
+)

--- a/ckanext/advancedauth/click.py
+++ b/ckanext/advancedauth/click.py
@@ -20,10 +20,12 @@ def reset_password(username):
     advancedauth reset_password <username>
     """
     if username is None:
-        print('Setting all non-admin users to reset their password upon next login')
+        print("Setting all non-admin users to reset their password upon next login")
         reset_all_users_passwords()
     else:
-        print("Setting user {} to reset their password upon next login".format(username))
+        print(
+            "Setting user {} to reset their password upon next login".format(username)
+        )
         reset_user_password(username)
 
 

--- a/ckanext/advancedauth/click.py
+++ b/ckanext/advancedauth/click.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import click
+from ckanext.advancedauth.command import reset_all_users_passwords, reset_user_password
+
+
+@click.group()
+def advancedauth():
+    """advancedauth commands
+    Usage:
+            advancedauth reset-password <username>
+
+                    Sets flag for user to reset password upon their next login
+                    'all' can optionally be used in place of username to set flag for all users
+    """
+    pass
+
+
+@advancedauth.command()
+@click.argument("username")
+def reset_password(username):
+    """
+    advancedauth reset_password <username>
+    """
+    if not username:
+        print('Setting all non-admin users to reset their password upon next login')
+        reset_all_users_passwords()
+    else:
+        print("Setting user {} to reset their password upon next login".format(username))
+        reset_user_password(username)
+
+
+def get_commands():
+    return [advancedauth]

--- a/ckanext/advancedauth/click.py
+++ b/ckanext/advancedauth/click.py
@@ -7,21 +7,19 @@ from ckanext.advancedauth.command import reset_all_users_passwords, reset_user_p
 def advancedauth():
     """advancedauth commands
     Usage:
-            advancedauth reset-password <username>
-
-                    Sets flag for user to reset password upon their next login
-                    'all' can optionally be used in place of username to set flag for all users
+            advancedauth reset_password --username=<username> to set flag for a specific user
+            advancedauth reset_password to reset passwords for all non-admin users.
     """
     pass
 
 
 @advancedauth.command()
-@click.argument("username")
+@click.option("--username", default=None, help="Username of user to reset password")
 def reset_password(username):
     """
     advancedauth reset_password <username>
     """
-    if not username:
+    if username is None:
         print('Setting all non-admin users to reset their password upon next login')
         reset_all_users_passwords()
     else:

--- a/ckanext/advancedauth/command.py
+++ b/ckanext/advancedauth/command.py
@@ -1,0 +1,33 @@
+import logging
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+from .model import advancedauthExtras
+
+log = logging.getLogger(__name__)
+
+
+def sysadmin_context():
+    user = toolkit.get_action("get_site_user")(
+        {"model": model, "ignore_auth": True}, {}
+    )
+    return {"ignore_auth": True, "user": user["name"], "auth_user_obj": None}
+
+
+def reset_all_users_passwords():
+    context = sysadmin_context()
+    users = toolkit.get_action("user_list")(context, {})
+    user_ids = [user.get("id") for user in users if not user.get("sysadmin", False)]
+    for userid in user_ids:
+        advancedauthExtras.update_password_date(
+            userid=userid, key="password_reset_required_date"
+        )
+    return "Password reset flag set for all users"
+
+
+def reset_user_password(username):
+    context = sysadmin_context()
+    user = toolkit.get_action("user_show")(context, {"id": username})
+    advancedauthExtras.update_password_date(
+        userid=user["id"], key="password_reset_required_date"
+    )
+    return "Password reset flag set for user: {}".format(username)

--- a/ckanext/advancedauth/middleware.py
+++ b/ckanext/advancedauth/middleware.py
@@ -37,14 +37,14 @@ class advancedauthMiddleware:
         if (
             userid
             and path_info not in self.overrides
-            and not path_info.startswith("/user/required_reset")
+            and not path_info.startswith("/user/reset")
         ):
             # username is not stored in advancedauth table and id is not available in identity
             sql = """
                     SELECT 
                         advancedauth_extras.key, 
                         advancedauth_extras.value,
-                        advancedauth_extras.user_id
+                        "user".name
                     FROM 
                         "user"
                     INNER JOIN 
@@ -58,10 +58,10 @@ class advancedauthMiddleware:
 
             if self.is_password_reset_required(rows):
                 first_row = rows[0]
-                user_id = first_row[
+                username = first_row[
                     2
                 ]  # each row from sql query has shape (key, value, user_id)
-                response = redirect(f"/user/required_reset/{user_id}")
+                response = redirect(f"/user/reset?name={username}")
                 return response(environ, start_response)
 
         # continue with the original application flow if not logged in or no reset required

--- a/ckanext/advancedauth/middleware.py
+++ b/ckanext/advancedauth/middleware.py
@@ -1,30 +1,93 @@
-from werkzeug.wrappers import Request, Response
-
+import logging
+import sqlalchemy as sa
+from dateutil import parser
+from werkzeug.wrappers import Request
+from werkzeug.utils import redirect
+from werkzeug.exceptions import HTTPException
 
 class advancedauthMiddleware:
-    def __init__(self, app):
+    def __init__(self, app, config):
         self.app = app
+        self.engine = sa.create_engine(config.get("sqlalchemy.url"))
         self.overrides = [
             "/",
             "/user/login",
             "/user/register",
-            "/user/logged_in",
             "/user/reset",
             "/user/_logout",
             "/user/logged_out",
             "/user/logged_out_redirect",
+            "/dataset",
+            "/about"
         ]
 
     def __call__(self, environ, start_response):
         request = Request(environ)
-        if (
-            request.environ.get("PATH_INFO", "") not in self.overrides
-            and "webassets" not in request.environ.get("PATH_INFO", "")
-            and "/api/i18n" not in request.environ.get("PATH_INFO", "")
-        ):
-            if not request.environ.get("repoze.who.identity", False):
-                res = Response(
-                    "Authorization Required", mimetype="text/plain", status=403
-                )
-                return res(environ, start_response)
+        path_info = request.path
+
+        # ignore static paths
+        static_paths = ['/base', '/webassets', '/images']
+        if any(path_info.startswith(p) for p in static_paths):
+            return self.app(environ, start_response)
+        
+        # check if the user is logged in before executing sql query
+        identity = request.environ.get("repoze.who.identity", {})
+        userid = identity.get("repoze.who.userid", None)
+        if userid and path_info not in self.overrides and not path_info.startswith("/user/required_reset"):
+            # username is not stored in advancedauth table and id is not available in identity
+            sql = """
+                    SELECT 
+                        advancedauth_extras.key, 
+                        advancedauth_extras.value,
+                        advancedauth_extras.user_id
+                    FROM 
+                        "user"
+                    INNER JOIN 
+                        advancedauth_extras ON "user".id = advancedauth_extras.user_id
+                    WHERE 
+                        "user".name = %s
+                        AND advancedauth_extras.key IN ('password_last_reset_date', 'password_reset_required_date')
+                  """
+            res = self.engine.execute(sql, userid)
+            rows = [row for row in res]
+
+            if self.is_password_reset_required(rows):
+                first_row = rows[0]
+                user_id = first_row[2] # each row from sql query has shape (key, value, user_id)
+                response = redirect(f"/user/required_reset/{user_id}")
+                return response(environ, start_response)
+
+        # continue with the original application flow if not logged in or no reset required
         return self.app(environ, start_response)
+
+    def is_password_reset_required(self, res):
+        password_last_reset_date = None
+        password_reset_required_date = None
+
+        for row in res:
+            key = row[0]
+            value = row[1]
+            if key == "password_last_reset_date":
+                password_last_reset_date = parser.parse(value)
+            elif key == "password_reset_required_date":
+                password_reset_required_date = parser.parse(value)
+
+        if password_reset_required_date:
+            if not password_last_reset_date or password_last_reset_date < password_reset_required_date:
+                return True
+        return False
+
+class advancedauthErrorLogMiddleware:
+    def __init__(self, app):
+        self.app = app
+        self.logger = logging.getLogger(__name__)
+
+    def __call__(self, environ, start_response):
+        try:
+            return self.app(environ, start_response)
+        except HTTPException as e:
+            self.logger.error(f"HTTPException: {e.description}")
+            raise
+        except Exception as e:
+            self.logger.error(f"Exception: {e}", exc_info=True)
+            raise

--- a/ckanext/advancedauth/model.py
+++ b/ckanext/advancedauth/model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Table, Column, ForeignKey, types
+from sqlalchemy import Table, Column, ForeignKey, types, delete, insert
 from sqlalchemy.exc import ArgumentError
 
 from ckan.model.meta import metadata, mapper, Session
@@ -70,6 +70,21 @@ class advancedauthExtras(DomainObject):
 
     def update(self, user, request):
         pass
+
+    @classmethod
+    def update_password_date(self, userid, key):
+        delete_stmt = (
+            delete(advancedauthExtras)
+            .where(advancedauthExtras.user_id == userid)
+            .where(advancedauthExtras.key == key)
+        )
+        insert_stmt = insert(advancedauthExtras).values(
+            user_id=userid, key=key, value=datetime.datetime.now()
+        )
+
+        Session.execute(delete_stmt)
+        Session.execute(insert_stmt)
+        Session.commit()
 
 
 class advancedauthAudit(DomainObject):

--- a/ckanext/advancedauth/plugin.py
+++ b/ckanext/advancedauth/plugin.py
@@ -6,6 +6,7 @@ from .helpers import helpers
 from .logic import actions
 from .model import initdb
 from .auditdata import audit_table
+from .middleware import advancedauthMiddleware, advancedauthErrorLogMiddleware
 
 
 class AdvancedauthPlugin(plugins.SingletonPlugin):
@@ -15,6 +16,7 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthFunctions, inherit=True)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.IMiddleware)
 
     #######################################################################
     # IBlueprint                                                          #
@@ -49,3 +51,12 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     # makes functions available in templates
     def get_helpers(self):
         return helpers
+
+    # IMiddleware
+    def make_middleware(self, app, config):
+        app = advancedauthMiddleware(app, config)
+        return app
+
+    def make_error_log_middleware(self, app, config):
+        app = advancedauthErrorLogMiddleware(app)
+        return app

--- a/ckanext/advancedauth/plugin.py
+++ b/ckanext/advancedauth/plugin.py
@@ -7,6 +7,7 @@ from .logic import actions
 from .model import initdb
 from .auditdata import audit_table
 from .middleware import advancedauthMiddleware, advancedauthErrorLogMiddleware
+from .click import get_commands
 
 
 class AdvancedauthPlugin(plugins.SingletonPlugin):
@@ -17,6 +18,7 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IMiddleware)
+    plugins.implements(plugins.IClick)
 
     #######################################################################
     # IBlueprint                                                          #
@@ -60,3 +62,7 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     def make_error_log_middleware(self, app, config):
         app = advancedauthErrorLogMiddleware(app)
         return app
+
+    # IClick
+    def get_commands(self):
+        return get_commands()

--- a/ckanext/advancedauth/plugin.py
+++ b/ckanext/advancedauth/plugin.py
@@ -8,6 +8,7 @@ from .model import initdb
 from .auditdata import audit_table
 from .middleware import advancedauthMiddleware, advancedauthErrorLogMiddleware
 from .click import get_commands
+from .blueprint import advancedauth_user
 
 
 class AdvancedauthPlugin(plugins.SingletonPlugin):
@@ -25,7 +26,7 @@ class AdvancedauthPlugin(plugins.SingletonPlugin):
     # Return a Flask Blueprint object to be registered by the app         #
     #######################################################################
     def get_blueprint(self):
-        return audit_table
+        return [audit_table, advancedauth_user]
 
     # IConfigurer
     # Adds templates to CKAN

--- a/ckanext/advancedauth/templates/user/request_reset.html
+++ b/ckanext/advancedauth/templates/user/request_reset.html
@@ -11,11 +11,14 @@
     <div class="module-content">
       {% block primary_content_inner %}
       <h1 class="page-heading">{{ _('Reset your password') }}</h1>
+      {% if request.args.get('name') %}
+        <p style="margin-top: 10px; margin-bottom: 10px">For enhanced security, we're asking some of our users to reset their passwords. We appreciate your cooperation in helping us maintain a secure environment for everyone.</p>
+      {% endif %}
       {% block form %}
         <form action="" method="post">
           <div class="form-group">
             <label for="field-username">{{ _('Email or username') }}</label>
-            <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
+            <input id="field-username" class="control-medium form-control" name="user" value="{{ request.args.get('name', '') }}" type="text" />
           </div>
           <div class="form-actions">
             {% block form_button %}

--- a/ckanext/advancedauth/templates/user/required_reset.html
+++ b/ckanext/advancedauth/templates/user/required_reset.html
@@ -1,0 +1,72 @@
+{% extends "page.html" %}
+{% import "macros/form.html" as form %}
+
+{% block subtitle %}{{ _('Reset Your Password') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ _('Password Reset') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+  <article class="module">
+    {% block primary_content_inner %}
+    <div class="module-content">
+      <h1 class="page-heading">
+        {% block page_heading %}{{ _('Reset Your Password') }}{% endblock %}
+      </h1>
+      <br />
+      <p>The mapMECFS team has requested a password change for your account.</p>
+      {% block form %}
+        <form action="" method="post">
+          {{ form.errors(error_summary) }}
+          <!-- ckan_user_update -->
+          <div style="display:none;">
+          {{ form.input('name', id='field-username', type='hidden', value=data.name) }}
+          {{ form.input('email', id='field-email', type='hidden', value=data.email) }}
+          </div>
+          {{ form.input('old_password',
+              type='password',
+              label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
+              id='field-password-old',
+              value=data.oldpassword,
+              error=errors.oldpassword,
+              classes=['control-medium'],
+              attrs={'autocomplete': 'off', 'class': 'form-control'}
+              ) }}
+          {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+          {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+          <div class="form-actions">
+            {% block form_button %}
+            <button class="btn btn-primary" type="submit" name="save">{{ _("Update Password") }}</button>
+            {% endblock %}
+          </div>
+        </form>
+      {% endblock %}
+    </div>
+    {% endblock %}
+  </article>
+{% endblock %}
+
+{% block secondary_content %}
+  {% block help %}
+  <section class="module module-narrow module-shallow">
+    {% block help_inner %}
+    <h2 class="module-heading">{{ _('How does this work?') }}</h2>
+    <div class="module-content">
+      <p>{% trans %}Simply enter a new password and we'll update your account{% endtrans %}</p>
+      <p>Your password must be 10 characters or longer, and consist of at least three of the following character sets: uppercase characters, lowercase characters, digits, punctuation & special characters. </p>
+    </div>
+    {% endblock %}
+  </section>
+  {% endblock %}
+{% endblock %}
+
+<script type="text/javascript">
+  var errors = document.querySelectorAll('.error-explanation li');
+  errors.forEach(function(error) {
+    // replace 'Password1:' and 'Password2:' with 'Password:'
+    var text = error.textContent;
+    text = text.replace("Password1:", "Password:").replace("Password2:", "Password:");
+    error.textContent = text;
+  });
+</script>


### PR DESCRIPTION
You can run the following to set all non-admin users to be required to reset their password:
```
docker exec -t mecfs_ckan bash -c "ckan advancedauth reset-password"
```
The following will work for any user including sysadmins:
```
docker exec -it mecfs_ckan bash -c "ckan advancedauth reset-password --username=<username>
```

Upon login and on subsequent routes, the user will be redirected to the `/user/required_reset/<id>` page. This page is derived from the edit_user_form.html template with all other fields stripped out except for the password fields.

One major revision is that originally I had intercepted only when the user logs in, but now it intercepts on all routes except for those listed in the middleware overrides attribute. It seems to work fine without much of a performance issue since we have a small table for users, but I think staging will be a better indicator.

Note: since I extended the perform reset view (to update the post method to set the reset field in the db), I went ahead and used the error_summary to fix https://jira.rti.org/browse/MECFSDEV-1753