### PR TITLE
100 add email confirmation field

### DIFF
--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -2,9 +2,7 @@ import datetime
 
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.mailer as mailer
-import ckan.model as model
 from ckan.plugins.toolkit import chained_action
-from ckan.logic import ValidationError
 from ckan.logic.action.create import user_create
 from ckan.logic.action.get import user_show
 from ckan.logic.action.update import user_update
@@ -28,6 +26,9 @@ def _modify_user_schema(context, mode):
         toolkit.config.get("ckanext.advancedauth.require_fullname", False)
     ):
         schema["fullname"] = [toolkit.get_validator("not_empty")]
+
+    # require both emails match when registering new user
+    schema["email"] = [get_validators()["confirm_email"]]
 
     # add required schema fields with not_empty validator
     for field in advancedauth_schema_keys["required"]:

--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -27,9 +27,6 @@ def _modify_user_schema(context, mode):
     ):
         schema["fullname"] = [toolkit.get_validator("not_empty")]
 
-    # require both emails match when registering new user
-    schema["email"] = [get_validators()["confirm_email"]]
-
     # add required schema fields with not_empty validator
     for field in advancedauth_schema_keys["required"]:
         schema[field] = [
@@ -66,6 +63,7 @@ def custom_user_create(context, data_dict):
     schema["email"] += [
         get_validators()["not_empty_string"],
         toolkit.get_validator("email_validator"),
+        get_validators()["confirm_email"],
     ]
 
     context = _modify_user_schema(context, "create")

--- a/ckanext/advancedauth/templates/user/new_user_form.html
+++ b/ckanext/advancedauth/templates/user/new_user_form.html
@@ -6,11 +6,12 @@
 
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("First and Last Name"), value=data.fullname, error=errors.fullname, classes=["control-medium"], is_required=fullname_req) }}
 
-  {{ form.input("email", id="field-email", label=_("Email (Institutional Email Preferred)"), type="email", placeholder=_("email@yourinstitution.org"), value=data.email, error=errors.email, classes=["control-medium"], is_required=True) }}
+  {{ form.input("email", id="field-email", label=_("Email (Institutional Email Preferred)"), type="email", placeholder=_("email@yourinstitution.org"), value=data.email, error=errors.email, classes=["control-medium email-input"], is_required=True) }}
   <!-- Helper text for the password field -->
   <p id="password-help" class="form-text">
     Your password must be 10 characters or longer, and consist of at least three of the following character sets: uppercase characters, lowercase characters, digits, punctuation & special characters.
   </p>
+  {{ form.input("email-confirm", id="field-email-confirm", label=_("Confirm Email"), type="email", placeholder=_("email@yourinstitution.org"), value=data["email-confirm"], error=errors.email, classes=["control-medium"], is_required=True) }}
   {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], is_required=True) }}
   {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password2, classes=["control-medium"], is_required=True) }}
 

--- a/ckanext/advancedauth/validators.py
+++ b/ckanext/advancedauth/validators.py
@@ -8,8 +8,20 @@ def not_empty_string(key, flattened_data, errors, context):
         raise Invalid("Field cannot be blank or consist of only spaces.")
 
 
+def confirm_email(key, flattened_data, errors, context):
+    email = flattened_data.get(key, "")
+    extras = flattened_data.get(("__extras",), {})
+    confirm_email = extras.get("email-confirm", "")
+
+    if not confirm_email:
+        return
+    if email != confirm_email:
+        raise Invalid("Emails do not match.")
+
+
 # published to the plugin
 def get_validators():
     return {
         "not_empty_string": not_empty_string,
+        "confirm_email": confirm_email,
     }

--- a/ckanext/advancedauth/validators.py
+++ b/ckanext/advancedauth/validators.py
@@ -13,8 +13,6 @@ def confirm_email(key, flattened_data, errors, context):
     extras = flattened_data.get(("__extras",), {})
     confirm_email = extras.get("email-confirm", "")
 
-    if not confirm_email:
-        return
     if email != confirm_email:
         raise Invalid("Emails do not match.")
 


### PR DESCRIPTION
PR adds an additional email field in user registration form as `Confirm Email`. I've added a validator on the backend to validate the two email fields are equal.