### PR TITLE
Ras login new user flow

### DIFF
--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -81,7 +81,7 @@ def my_package_update(context, data_dict=None):
 
 # this permission function denies access to users with no organizations, which is self-registered
 # users who have not yet been approved by mapMECFS admins
-def only_approved_users(context, data_dict=None):
+def only_approved_users(context, data_dict=None, func_name=None):
     func = toolkit.get_action("organization_list_for_user")
     user_id = ""
     # If auth_user_obj exists in context, use it. Otherwise, use user_obj
@@ -96,6 +96,12 @@ def only_approved_users(context, data_dict=None):
         orgs = func({}, {"id": user_id})
         if len(orgs):
             return {"success": True}
+        # allow new user to edit their own profile for "registration"
+        if func_name == "user_show":
+            requested_user_id = data_dict.get("id", "")
+            user_obj = context.get("auth_user_obj", {})
+            if requested_user_id == user_obj.id or requested_user_id == user_obj.name:
+                return {"success": True}
         approval_message = toolkit.config.get(
             "ckanext.advancedauth.only_approved_users_message",
             "Your account is pending approval",
@@ -149,7 +155,7 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # run only_approved_users
     # this aborts with 403 if failed
     if only_approved_users_var and func_name in only_approved_users_actions:
-        only_approved_users(context, data_dict)
+        only_approved_users(context, data_dict, func_name)
 
     ## setup only_authors_can_edit
     only_authors_can_edit = toolkit.asbool(

--- a/ckanext/advancedauth/blueprint.py
+++ b/ckanext/advancedauth/blueprint.py
@@ -1,17 +1,12 @@
 import ckan.lib.base as base
 import ckan.lib.helpers as h
-import ckan.lib.mailer as mailer
 import ckan.lib.navl.dictization_functions as dictization_functions
 import ckan.logic as logic
-import ckan.model as model
 
-from ckan.common import _, g, request, current_user
-from ckan.views.user import RequestResetView, PerformResetView, EditView, RegisterView
+from ckan.common import _, g, request
+from ckan.views.user import EditView
 from .model import advancedauthExtras as ae
-from six import text_type
 from flask import Blueprint, request
-from .captcha import check_captcha
-from ckan.lib import captcha
 
 import logging
 
@@ -20,51 +15,9 @@ log = logging.getLogger(__name__)
 advancedauth_user = Blueprint("advancedauth_user", __name__, url_prefix="/user")
 
 
-class ExtendedRequestResetView(RequestResetView):
-    def get(self) -> str:
-        self._prepare()
-        return base.render("user/request_reset.html", {"username": current_user.name})
-
-
-class ExtendedPerformResetView(PerformResetView):
-    # This is a copy of the PerformResetView post method from ckan/views/user.py
-    # Adds update_password_date and changes validation error dict to error_summary
-    def post(self, id):
-        context, user_dict = self._prepare(id)
-        context["reset_password"] = True
-        user_state = user_dict["state"]
-        error_summary = None
-        try:
-            new_password = self._get_form_password()
-            user_dict["password"] = new_password
-            username = request.form.get("name")
-            if username is not None and username != "":
-                user_dict["name"] = username
-            user_dict["reset_key"] = g.reset_key
-            user_dict["state"] = model.State.ACTIVE
-            logic.get_action("user_update")(context, user_dict)
-            mailer.create_reset_key(context["user_obj"])
-            ae.update_password_date(user_dict["id"], "password_last_reset_date")
-            h.flash_success(_("Your password has been reset."))
-            return h.redirect_to("home.index")
-        except logic.NotAuthorized:
-            h.flash_error(_("Unauthorized to edit user %s") % id)
-        except logic.NotFound:
-            h.flash_error(_("User not found"))
-        except dictization_functions.DataError:
-            h.flash_error(_("Integrity Error"))
-        except logic.ValidationError as e:
-            error_summary = e.error_summary
-        except ValueError as e:
-            error_summary = text_type(e)
-        user_dict["state"] = user_state
-        extra_vars = {"user_dict": user_dict, "error_summary": error_summary}
-        return base.render("user/perform_reset.html", extra_vars)
-
-
 class ExtendedEditView(EditView):
-    # This is a copy of the EditView post method from ckan/views/user.py reused for required_reset page
-    # Adds update_password_date
+    # This is a copy of the EditView post method from ckan/views/user.py reused for new user register/profile page
+    # Adds update registration_complete update
     def post(self, id=None):
         context, id = self._prepare(id)
         if not context["save"]:
@@ -134,19 +87,6 @@ class ExtendedEditView(EditView):
         return base.render("user/register.html", extra_vars)
 
 
-class ExtendedRegisterView(RegisterView):
-    # Override original check_recaptcha (google recaptcha) with turnstile check_captcha
-    def post(self):
-        captcha.check_recaptcha = check_captcha
-        return super().post()
-
-
-advancedauth_user.add_url_rule(
-    "/reset/<id>", view_func=ExtendedPerformResetView.as_view(str("perform_reset"))
-)
-advancedauth_user.add_url_rule(
-    "/required_reset/<id>", view_func=ExtendedEditView.as_view(str("required_reset"))
-)
 advancedauth_user.add_url_rule(
     "/register", view_func=ExtendedEditView.as_view(str("register"))
 )

--- a/ckanext/advancedauth/blueprint.py
+++ b/ckanext/advancedauth/blueprint.py
@@ -4,7 +4,6 @@ import ckan.lib.mailer as mailer
 import ckan.lib.navl.dictization_functions as dictization_functions
 import ckan.logic as logic
 import ckan.model as model
-import ckan.lib.authenticator as authenticator
 
 from ckan.common import _, g, request, current_user
 from ckan.views.user import RequestResetView, PerformResetView, EditView, RegisterView
@@ -89,24 +88,10 @@ class ExtendedEditView(EditView):
             base.abort(400, _("Integrity Error"))
         data_dict.setdefault("activity_streams_email_notifications", False)
 
-        context["message"] = data_dict.get("log_message", "")
         data_dict["id"] = id
 
-        if data_dict["password1"] and data_dict["password2"]:
-            identity = {"login": g.user, "password": data_dict["old_password"]}
-            auth = authenticator.UsernamePasswordAuthenticator()
-
-            if auth.authenticate(request.environ, identity) != g.user:
-                errors = {"oldpassword": [_("Password entered was incorrect")]}
-                error_summary = (
-                    {_("Old Password"): _("incorrect password")}
-                    if not g.userobj.sysadmin
-                    else {_("Sysadmin Password"): _("incorrect password")}
-                )
-                return self.get(id, data_dict, errors, error_summary)
-
         try:
-            user = logic.get_action("ckan_user_update")(context, data_dict)
+            user = logic.get_action("user_update")(context, data_dict)
         except logic.NotAuthorized:
             base.abort(403, _("Unauthorized to edit user %s") % id)
         except logic.NotFound:
@@ -116,9 +101,10 @@ class ExtendedEditView(EditView):
             error_summary = e.error_summary
             return self.get(id, data_dict, errors, error_summary)
 
-        h.flash_success(_("Password updated"))
-        ae.update_password_date(data_dict["id"], "password_last_reset_date")
+        h.flash_success(_("Profile updated"))
+        ae.update_user_registration_check(data_dict["id"], "true")
         resp = h.redirect_to("user.read", id=user["name"])
+
         return resp
 
     def get(self, id=None, data=None, errors=None, error_summary=None):
@@ -145,7 +131,7 @@ class ExtendedEditView(EditView):
         errors = errors or {}
         extra_vars = {"data": data, "errors": errors, "error_summary": error_summary}
 
-        return base.render("user/required_reset.html", extra_vars)
+        return base.render("user/register.html", extra_vars)
 
 
 class ExtendedRegisterView(RegisterView):
@@ -162,5 +148,5 @@ advancedauth_user.add_url_rule(
     "/required_reset/<id>", view_func=ExtendedEditView.as_view(str("required_reset"))
 )
 advancedauth_user.add_url_rule(
-    "/register", view_func=ExtendedRegisterView.as_view(str("register"))
+    "/register", view_func=ExtendedEditView.as_view(str("register"))
 )

--- a/ckanext/advancedauth/logic.py
+++ b/ckanext/advancedauth/logic.py
@@ -146,25 +146,17 @@ def custom_user_create(context, data_dict):
         subject = toolkit.config.get(
             "ckanext.advancedauth.welcome_email_subject", default_subject
         )
-        body = ""
-        body_html = """
-        <html>
-        <body>
-            <p><strong>Notice Regarding Delays in Account Services</strong></p>
-            <p>
-            Thank you for your interest in mapMECFS. Your request has been received. Currently users may experience delays in the approval of new accounts and in receiving support services.
-            </p>
-            <p>
-            We remain committed to serving the research community and will resume full functionality as soon as possible. Thank you for your patience and understanding.
-            </p>
-            <p>
-            Best regards,<br>
-            The mapMECFS Team
-            </p>
-        </body>
-        </html>
-        """
-        mailer.mail_recipient(recipient_name, recipient_email, subject, body, body_html)
+        body = "Thank you for registering for " + toolkit.config.get(
+            "ckan.site_title", ""
+        )
+        body += "\n"
+        # TODO: Add better tooling for sites. This is very fragile and fails on many special characters.
+        # We should specify a location for an email template
+        if toolkit.config.get("ckanext.advancedauth.welcome_email_text", False):
+            body += toolkit.config.get("ckanext.advancedauth.welcome_email_text")
+            body += "\n"
+        body += toolkit.config.get("ckan.site_title", "") + " Team"
+        mailer.mail_recipient(recipient_name, recipient_email, subject, body)
 
     return user_dict
 

--- a/ckanext/advancedauth/model.py
+++ b/ckanext/advancedauth/model.py
@@ -86,6 +86,21 @@ class advancedauthExtras(DomainObject):
         Session.execute(insert_stmt)
         Session.commit()
 
+    @classmethod
+    def update_user_registration_check(self, userid, value):
+        delete_stmt = (
+            delete(advancedauthExtras)
+            .where(advancedauthExtras.user_id == userid)
+            .where(advancedauthExtras.key == "registration_complete")
+        )
+        insert_stmt = insert(advancedauthExtras).values(
+            user_id=userid, key="registration_complete", value=value
+        )
+
+        Session.execute(delete_stmt)
+        Session.execute(insert_stmt)
+        Session.commit()
+
 
 class advancedauthAudit(DomainObject):
     def __repr__(self):

--- a/ckanext/advancedauth/templates/user/edit_user_form.html
+++ b/ckanext/advancedauth/templates/user/edit_user_form.html
@@ -5,14 +5,16 @@
   {{ form.errors(error_summary) }}
 
   <fieldset>
+    {% if not disable_form_title %}
     <legend>{{ _('Change details') }}</legend>
-    
+    {% endif %}
+
     {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
 
     {% set fullname_req = h.advancedauth_require_fullname() %}
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium'], is_required=fullname_req) }}
 
-    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=True) }}
+    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
 
     {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 
@@ -52,23 +54,6 @@
       {% endif %}
     {% endfor %}
 
-  </fieldset>
-
-  <fieldset>
-    <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password',
-                  type='password',
-                  label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
-                  id='field-password',
-                  value=data.oldpassword,
-                  error=errors.oldpassword,
-                  classes=['control-medium'],
-                  attrs={'autocomplete': 'off', 'class': 'form-control'}
-                  ) }}
-
-    {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'} ) }}
-
-    {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'}) }}
   </fieldset>
 
   <div class="form-actions">

--- a/ckanext/advancedauth/templates/user/register.html
+++ b/ckanext/advancedauth/templates/user/register.html
@@ -1,0 +1,37 @@
+{% extends "page.html" %}
+
+{% block primary_content %}
+  <section class="module">
+    <div class="module-content">
+      <div class="row">
+        <div class="col-lg-10 login-container">
+          <div style="padding: 16px 32px;">
+            <h2>Finish Setting Up Your Account</h2>
+            <p class="intro-text">Welcome to mapMECFS! To use our site, you just need to provide a few more details. Note that some fields are optional.</p>
+              {% set data = data %}
+              {% set disable_form_title = true %}
+              {% include "user/edit_user_form.html" %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block secondary %}{% endblock %}
+{% block styles %}
+  {{ super() }}
+  <style>
+    .login-container {
+      background-color: white;
+      justify-content: center;
+      align-items: center;
+      padding: 0px !important;
+      border: 1px solid rgb(215,228,231);
+    }
+    .intro-text {
+      padding-top: 16px;
+      padding-bottom: 16px;
+    }
+  </style>
+{% endblock %}


### PR DESCRIPTION
PR changes:
- Update advancedauth authorization to allow new users to edit their own profile details (for registration form submission)
- Adds `register.html` template that renders at route `/user/register`. Reason: extended user edit action to also update the db for a `registration_complete` field check.
- User edit form modifications
  - Removed password fields
  - Disabled email input field
- Removed password reset routes / helper functions for password reset middleware

I also rolled into this PR the commit to revert the temporary new registration email from a few months ago. 