### PR TITLE
Create organization auth bug

### DIFF
--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -50,7 +50,12 @@ def advancedauth_check_access(next_func, context, data_dict=None):
 # this permission, added to the package_update action, only allows the original creator of the
 # dataset OR an organizational admin to update the package. This is so that "editor" members
 # of organization can't edit each others datasets
-def my_package_update(context, data_dict=None):
+def check_package_update(context, data_dict=None, func_name=None):
+    only_authors_can_edit = toolkit.asbool(
+        toolkit.config.get("ckanext.advancedauth.only_authors_can_edit") or False
+    )
+    if not func_name == "package_update" or not only_authors_can_edit:
+        return False
     if not data_dict:
         data_dict = {"id": context.get("package").id}
     package = toolkit.get_action("package_show")(context, data_dict)
@@ -74,14 +79,28 @@ def my_package_update(context, data_dict=None):
         success_conditions += 1
 
     if success_conditions > 0:
-        return {"success": True}
+        return True
     else:
-        return {"success": False}
+        raise toolkit.NotAuthorized("You do not have permission to edit this dataset")
 
 
 # this permission function denies access to users with no organizations, which is self-registered
 # users who have not yet been approved by mapMECFS admins
-def only_approved_users(context, data_dict=None, func_name=None):
+def check_only_approved_users(context, data_dict=None, func_name=None):
+    only_approved_users_var = toolkit.asbool(
+        toolkit.config.get("ckanext.advancedauth.only_approved_users") or False
+    )
+    only_approved_users_actions = [
+        "package_show",
+        "user_list",  # integration tool checks user_list access
+        "user_show",
+        "organization_list",
+        "group_list",
+    ]
+
+    if not only_approved_users_var or func_name not in only_approved_users_actions:
+        return False
+
     func = toolkit.get_action("organization_list_for_user")
     user_id = ""
     # If auth_user_obj exists in context, use it. Otherwise, use user_obj
@@ -95,13 +114,13 @@ def only_approved_users(context, data_dict=None, func_name=None):
     if user_id:
         orgs = func({}, {"id": user_id})
         if len(orgs):
-            return {"success": True}
+            return True
         # allow new user to edit their own profile for "registration"
         if func_name == "user_show":
             requested_user_id = data_dict.get("id", "")
             user_obj = context.get("auth_user_obj", {})
             if requested_user_id == user_obj.id or requested_user_id == user_obj.name:
-                return {"success": True}
+                return True
         approval_message = toolkit.config.get(
             "ckanext.advancedauth.only_approved_users_message",
             "Your account is pending approval",
@@ -121,51 +140,17 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # get function name
     func_name = next_func.__name__
 
-    ## setup variables for disallow_anonymous_access
-    disallow_anonymous_access = toolkit.asbool(
-        toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access") or False
-    )
-
-    action_allowlist = toolkit.aslist(
-        toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
-    )
-
-    ## run advancedauth_check_access
-    if disallow_anonymous_access and func_name not in action_allowlist:
-        advancedauth_check_access(next_func, context, data_dict)
-
-    # if user is sysadmin, skip all checks
-    user = context.get("auth_user_obj", "")
-    if user and hasattr(user, "sysadmin") and user.sysadmin:
-        if not user.state == "active":
-            raise toolkit.NotAuthorized()
+    if check_anonymous_access(func_name, context):
         return {"success": True}
 
-    # set up variables for only_approved_users
-    only_approved_users_var = toolkit.asbool(
-        toolkit.config.get("ckanext.advancedauth.only_approved_users") or False
-    )
-    only_approved_users_actions = [
-        "package_show",
-        "user_list",  # integration tool checks user_list access
-        "user_show",
-        "organization_list",
-    ]
+    if check_sysadmin_access(context):
+        return {"success": True}
 
-    # run only_approved_users
-    # this aborts with 403 if failed
-    if only_approved_users_var and func_name in only_approved_users_actions:
-        only_approved_users(context, data_dict, func_name)
+    if check_only_approved_users(context, data_dict, func_name):
+        return {"success": True}
 
-    ## setup only_authors_can_edit
-    only_authors_can_edit = toolkit.asbool(
-        toolkit.config.get("ckanext.advancedauth.only_authors_can_edit") or False
-    )
-
-    if func_name == "package_update" and only_authors_can_edit:
-        package_update = my_package_update(context, data_dict)
-        if package_update.get("success") == False:
-            return package_update
+    if check_package_update(context, data_dict, func_name):
+        return {"success": True}
 
     return next_func(context, data_dict)
 
@@ -178,3 +163,35 @@ def get_actions_list():
     for action in actions:
         actions_list[action] = advancedauth_wrapper_function
     return actions_list
+
+
+def check_anonymous_access(func_name, context):
+    disallow_anonymous_access = toolkit.asbool(
+        toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access") or False
+    )
+
+    action_allowlist = toolkit.aslist(
+        toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
+    )
+
+    # if anonymous access is allowed or action is in exception list, skip the auth check
+    if not disallow_anonymous_access:
+        return True
+
+    # if anonymous access is disallowed, and the action is not in the exception list, check if user is logged in
+    if disallow_anonymous_access and func_name not in action_allowlist:
+        if not context.get("auth_user_obj", False) and not context.get("user", False):
+            err_msg = "Authentication is required to access this feature ({0})".format(
+                func_name
+            )
+            raise toolkit.NotAuthorized(err_msg)
+    return False
+
+
+def check_sysadmin_access(context):
+    user = context.get("auth_user_obj", "")
+    if user and hasattr(user, "sysadmin") and user.sysadmin:
+        if not user.state == "active":
+            raise toolkit.NotAuthorized()
+        return True
+    return False

--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -79,10 +79,10 @@ def check_package_update(context, data_dict=None, func_name=None):
     if len(users_in_org) > 0:
         success_conditions += 1
 
-    if success_conditions > 0:
-        return True
-    else:
+    if success_conditions == 0:
         raise toolkit.NotAuthorized("You do not have permission to edit this dataset")
+
+    return False
 
 
 def check_only_approved_users(context, data_dict=None, func_name=None):
@@ -155,9 +155,7 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
         return {"success": True}
 
     check_only_approved_users(context, data_dict, func_name)
-
-    if check_package_update(context, data_dict, func_name):
-        return {"success": True}
+    check_package_update(context, data_dict, func_name)
 
     return next_func(context, data_dict)
 

--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -41,16 +41,27 @@ def advancedauth_auditor(next_func, context, data_dict=None):
 # dataset OR an organizational admin to update the package. This is so that "editor" members
 # of organization can't edit each others datasets
 def check_package_update(context, data_dict=None, func_name=None):
+    # custom auth not applicable for actions other than package_update. continue sequence of checks
+    if not func_name == "package_update":
+        return False
     only_authors_can_edit = toolkit.asbool(
         toolkit.config.get("ckanext.advancedauth.only_authors_can_edit") or False
     )
-    if not func_name == "package_update" or not only_authors_can_edit:
+    # skip custom auth if setting is not enabled
+    if not only_authors_can_edit:
         return False
     if not data_dict:
         data_dict = {"id": context.get("package").id}
     package = toolkit.get_action("package_show")(context, data_dict)
 
-    user_id = context.get("auth_user_obj").id
+    user_id = ""
+    # If auth_user_obj exists in context, use it. Otherwise, use user_obj
+    if context.get("auth_user_obj", False) and hasattr(
+        context.get("auth_user_obj"), "id"
+    ):
+        user_id = context.get("auth_user_obj").id
+    elif context.get("user_obj", False) and hasattr(context.get("user_obj"), "id"):
+        user_id = context.get("user_obj").id
     success_conditions = 0
     # if the current user created the dataset
     if user_id == package.get("creator_user_id", ""):
@@ -74,12 +85,18 @@ def check_package_update(context, data_dict=None, func_name=None):
         raise toolkit.NotAuthorized("You do not have permission to edit this dataset")
 
 
-# this permission function denies access to users with no organizations, which is self-registered
-# users who have not yet been approved by mapMECFS admins
 def check_only_approved_users(context, data_dict=None, func_name=None):
+    """
+    Approved users are those who belong to an org. The following actions are restricted to approved users only:
+        package_show • user_list • user_show • organization_list • group_list
+    """
     only_approved_users_var = toolkit.asbool(
         toolkit.config.get("ckanext.advancedauth.only_approved_users") or False
     )
+    # continue sequence of checks if only_approved_users_var is False
+    if not only_approved_users_var:
+        return False
+
     only_approved_users_actions = [
         "package_show",
         "user_list",  # integration tool checks user_list access
@@ -88,7 +105,8 @@ def check_only_approved_users(context, data_dict=None, func_name=None):
         "group_list",
     ]
 
-    if not only_approved_users_var or func_name not in only_approved_users_actions:
+    # continue sequence of checks if action is not in the only_approved_users_actions list
+    if func_name not in only_approved_users_actions:
         return False
 
     func = toolkit.get_action("organization_list_for_user")
@@ -103,8 +121,9 @@ def check_only_approved_users(context, data_dict=None, func_name=None):
 
     if user_id:
         orgs = func({}, {"id": user_id})
+        # continue sequence of checks if user belongs to at least one organization
         if len(orgs):
-            return True
+            return False
         # allow new user to edit their own profile for "registration"
         if func_name == "user_show":
             requested_user_id = data_dict.get("id", "")
@@ -115,7 +134,7 @@ def check_only_approved_users(context, data_dict=None, func_name=None):
             "ckanext.advancedauth.only_approved_users_message",
             "Your account is pending approval",
         )
-        toolkit.abort(403, approval_message)
+        raise toolkit.NotAuthorized(approval_message)
     else:
         raise toolkit.NotAuthorized("You must be logged in to access this feature")
 
@@ -130,19 +149,14 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     # get function name
     func_name = next_func.__name__
 
-    if check_anonymous_access(func_name, context):
+    check_anonymous_access(func_name, context)
+
+    if check_sysadmin_access(context, func_name):
         return {"success": True}
 
-    if check_sysadmin_access(context):
-        return {"success": True}
-
-    if check_only_approved_users(context, data_dict, func_name):
-        return {"success": True}
+    check_only_approved_users(context, data_dict, func_name)
 
     if check_package_update(context, data_dict, func_name):
-        return {"success": True}
-
-    if check_create_organization(context, func_name):
         return {"success": True}
 
     return next_func(context, data_dict)
@@ -159,21 +173,35 @@ def get_actions_list():
 
 
 def check_anonymous_access(func_name, context):
+    """
+    Anonymous users are those not logged in. mapMECFS currently disallows anonymous access except for the following actions:
+        request_reset • user_reset • site_read • user_create • package_search • datastore_search • organization_list_for_user • package_create • sysadmin
+    The setting for allowing anonymous access is untested and should not be enabled.
+    The authorization function has no explicit approvals hence the reason for including package_create.
+    """
     disallow_anonymous_access = toolkit.asbool(
         toolkit.config.get("ckanext.advancedauth.disallow_anonymous_access") or False
     )
+    allow_anonymous_access = not disallow_anonymous_access
 
     action_allowlist = toolkit.aslist(
         toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
     )
 
-    # if anonymous access is allowed, skip the auth check
-    if not disallow_anonymous_access:
-        return True
+    # if anonymous access is allowed, continue sequence of checks
+    if allow_anonymous_access:
+        return False
 
-    # if anonymous access is disallowed, and the action is not in the exception list, check if user is logged in
+    # if anonymous access is disallowed, and the action is not in the exception list, explicitly deny for anonymous users
     if disallow_anonymous_access and func_name not in action_allowlist:
-        if not context.get("auth_user_obj", False) and not context.get("user", False):
+        user_id = ""
+        if context.get("auth_user_obj", False) and hasattr(
+            context.get("auth_user_obj"), "id"
+        ):
+            user_id = context.get("auth_user_obj").id
+        elif context.get("user_obj", False) and hasattr(context.get("user_obj"), "id"):
+            user_id = context.get("user_obj").id
+        if not user_id:
             err_msg = "Authentication is required to access this feature ({0})".format(
                 func_name
             )
@@ -181,18 +209,19 @@ def check_anonymous_access(func_name, context):
     return False
 
 
-def check_sysadmin_access(context):
+def check_sysadmin_access(context, func_name):
     user = context.get("auth_user_obj", "")
     if user and hasattr(user, "sysadmin") and user.sysadmin:
+        # explict deny for deleted users
         if not user.state == "active":
-            raise toolkit.NotAuthorized()
+            raise toolkit.NotAuthorized("sysadmin was deleted")
+        # explicit approve action if user is sysadmin
         return True
+
+    # user is not sysadmin - explicit deny for these actions
+    sysadmin_only_actions = ["organization_create", "group_create"]
+    if func_name in sysadmin_only_actions:
+        raise toolkit.NotAuthorized(f"only sysadmins may perform {func_name}")
+
+    # continue sequence of checks
     return False
-
-
-def check_create_organization(context, func_name=None):
-    if func_name != "organization_create" and func_name != "group_create":
-        return False
-    if check_sysadmin_access(context):
-        return True
-    raise toolkit.NotAuthorized("You do not have permission to create an organization")

--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -152,6 +152,9 @@ def advancedauth_wrapper_function(next_func, context, data_dict=None):
     if check_package_update(context, data_dict, func_name):
         return {"success": True}
 
+    if check_create_organization(context, func_name):
+        return {"success": True}
+
     return next_func(context, data_dict)
 
 
@@ -195,3 +198,11 @@ def check_sysadmin_access(context):
             raise toolkit.NotAuthorized()
         return True
     return False
+
+
+def check_create_organization(context, func_name=None):
+    if func_name != "organization_create" and func_name != "group_create":
+        return False
+    if check_sysadmin_access(context):
+        return True
+    raise toolkit.NotAuthorized("You do not have permission to create an organization")

--- a/ckanext/advancedauth/auth.py
+++ b/ckanext/advancedauth/auth.py
@@ -37,16 +37,6 @@ def advancedauth_auditor(next_func, context, data_dict=None):
         audit.save()
 
 
-# checks to see if the user is logged in and aborts with a 403 if not
-def advancedauth_check_access(next_func, context, data_dict=None):
-    func_name = next_func.__name__
-    if not context.get("auth_user_obj", False) and not context.get("user", False):
-        err_msg = "Authentication is required to access this feature ({0})".format(
-            func_name
-        )
-        raise toolkit.NotAuthorized(err_msg)
-
-
 # this permission, added to the package_update action, only allows the original creator of the
 # dataset OR an organizational admin to update the package. This is so that "editor" members
 # of organization can't edit each others datasets
@@ -177,7 +167,7 @@ def check_anonymous_access(func_name, context):
         toolkit.config.get("ckanext.advancedauth.action_allowlist", "")
     )
 
-    # if anonymous access is allowed or action is in exception list, skip the auth check
+    # if anonymous access is allowed, skip the auth check
     if not disallow_anonymous_access:
         return True
 

--- a/ckanext/advancedauth/tests/test_plugin.py
+++ b/ckanext/advancedauth/tests/test_plugin.py
@@ -3,6 +3,7 @@
 import pytest
 import ckan.logic as logic
 import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
 
 from ckanext.advancedauth.model import advancedauthAudit
 import random
@@ -172,6 +173,36 @@ class TestPlugin(object):
             logic.check_access(
                 "package_update",
                 {"user": different_org_admin["id"]},
+                {"id": dataset["name"]},
+            )
+
+    def test_package_update_creator_removed_from_org(self):
+        """
+        When a dataset creator is removed from the organization that owns the dataset,
+        they should no longer be able to update the dataset.
+        """
+        sysadmin_user = factories.Sysadmin()
+        dataset_creator = factories.User()
+        owner_org = factories.Organization(
+            users=[{"name": dataset_creator["id"], "capacity": "admin"}]
+        )
+        dataset = factories.Dataset(
+            owner_org=owner_org["id"], private=False, user=dataset_creator
+        )
+
+        # remove creator's membership so core CKAN will now reject package_update
+        helpers.call_action(
+            "member_delete",
+            {"user": sysadmin_user["name"]},
+            id=owner_org["id"],
+            object=dataset_creator["id"],
+            object_type="user",
+        )
+
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access(
+                "package_update",
+                {"user": dataset_creator["id"]},
                 {"id": dataset["name"]},
             )
 

--- a/ckanext/advancedauth/tests/test_plugin.py
+++ b/ckanext/advancedauth/tests/test_plugin.py
@@ -134,14 +134,16 @@ class TestPlugin(object):
 
     def test_package_update(self):
         """
-        For a given dataset, only the dataset creator or an organizational admin may update it.
+        For a given dataset, only an organizational admin or creator+editor may update it.
         """
         org_user_dataset_creator = factories.User()
+        org_user_editor = factories.User()
         org_user_member = factories.User()
         org_user_admin = factories.User()
         owner_org = factories.Organization(
             users=[
-                {"name": org_user_dataset_creator["id"], "capacity": "member"},
+                {"name": org_user_dataset_creator["id"], "capacity": "editor"},
+                {"name": org_user_editor["id"], "capacity": "editor"},
                 {"name": org_user_member["id"], "capacity": "member"},
                 {"name": org_user_admin["id"], "capacity": "admin"},
             ]
@@ -156,6 +158,14 @@ class TestPlugin(object):
             {"user": org_user_dataset_creator["id"]},
             {"id": dataset["name"]},
         )
+
+        # check another editor in the same org cannot update a dataset they did not author
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access(
+                "package_update",
+                {"user": org_user_editor["id"]},
+                {"id": dataset["name"]},
+            )
 
         # check org admin of same org can update dataset
         assert logic.check_access(

--- a/ckanext/advancedauth/tests/test_plugin.py
+++ b/ckanext/advancedauth/tests/test_plugin.py
@@ -1,12 +1,12 @@
 """Tests for plugin.py."""
 
 import pytest
-import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 import ckan.tests.factories as factories
-import ckan.tests.helpers as helpers
 
 from ckanext.advancedauth.model import advancedauthAudit
+import random
+import string
 from ckanext.advancedauth.helpers import (
     advancedauth_must_view_privacy_policy,
     advancedauth_must_view_terms_of_service,
@@ -35,6 +35,12 @@ def test_must_view_terms_of_service_empty_string():
 
 # These plugins are included to suppress warnings: recline_view image_view
 @pytest.mark.ckan_config("ckan.plugins", "recline_view image_view advancedauth")
+@pytest.mark.ckan_config("ckanext.advancedauth.disallow_anonymous_access", "true")
+@pytest.mark.ckan_config(
+    "ckanext.advancedauth.action_allowlist",
+    "request_reset user_reset site_read user_create package_search datastore_search organization_list_for_user package_create sysadmin",
+)
+@pytest.mark.ckan_config("ckanext.advancedauth.only_authors_can_edit", "true")
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
 class TestPlugin(object):
     def test_member_delete_organization(self):
@@ -64,6 +70,110 @@ class TestPlugin(object):
         )
         with pytest.raises(logic.NotAuthorized):
             logic.check_access("resource_show", {"user": ""}, {"id": resource["id"]})
+
+    def test_only_sysadmin_users(self):
+        """
+        Our custom authorization function explicitly denies the following actions for all users except sysadmin:
+            organization_create • group_create
+        Other auth checks including default CKAN are still in place.
+        """
+        sysadmin_user = factories.Sysadmin()
+        non_sysadmin_user = factories.User()
+        org_name = "".join(random.choices(string.ascii_lowercase, k=8))
+
+        assert logic.check_access(
+            "organization_create", {"user": sysadmin_user["id"]}, {"name": org_name}
+        )
+
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access(
+                "organization_create",
+                {"user": non_sysadmin_user["id"]},
+                {"name": org_name},
+            )
+
+    def test_anonymous_users(self):
+        """
+        Anonymous users are those not logged in. mapMECFS currently disallows anonymous access except for the following actions:
+            request_reset • user_reset • site_read • user_create • package_search • datastore_search • organization_list_for_user • package_create • sysadmin
+        The setting for allowing anonymous access is untested and should not be enabled.
+        """
+        # Authorization function will allow actions listed above to proceed in sequence of checks. Here we test for user_create
+        assert logic.check_access("user_create", {"user": ""})
+
+        # Authorization function should always deny any actions not explicitly listed for anonymous users. Current_package_list_with_resources is an example
+        # that is not explicitly checked, so we test for this.
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access("current_package_list_with_resources", {"user": ""})
+
+    def test_only_approved_users(self):
+        """
+        Approved users are those who belong to an org. The following actions are restricted to approved users only:
+            package_show • user_list • user_show • organization_list • group_list
+        """
+        owner_user = factories.User()
+        owner_org = factories.Organization(
+            users=[{"name": owner_user["id"], "capacity": "member"}]
+        )
+        owner_dataset = factories.Dataset(owner_org=owner_org["id"], private=True)
+        no_org_user = factories.User()
+
+        # Authorization function will allow actions listed above to proceed in sequence of checks. Here package_show is tested
+        assert logic.check_access(
+            "package_show", {"user": owner_user["id"]}, {"id": owner_dataset["name"]}
+        )
+
+        # User with no orgs should not be able to invoke approved-users-only actions. Here package_show is tested
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access(
+                "package_show",
+                {"user": no_org_user["id"]},
+                {"id": owner_dataset["name"]},
+            )
+
+    def test_package_update(self):
+        """
+        For a given dataset, only the dataset creator or an organizational admin may update it.
+        """
+        org_user_dataset_creator = factories.User()
+        org_user_member = factories.User()
+        org_user_admin = factories.User()
+        owner_org = factories.Organization(
+            users=[
+                {"name": org_user_dataset_creator["id"], "capacity": "member"},
+                {"name": org_user_member["id"], "capacity": "member"},
+                {"name": org_user_admin["id"], "capacity": "admin"},
+            ]
+        )
+        dataset = factories.Dataset(
+            owner_org=owner_org["id"], private=True, user=org_user_dataset_creator
+        )
+
+        # check creator can update their own dataset
+        assert logic.check_access(
+            "package_update",
+            {"user": org_user_dataset_creator["id"]},
+            {"id": dataset["name"]},
+        )
+
+        # check org admin of same org can update dataset
+        assert logic.check_access(
+            "package_update",
+            {"user": org_user_admin["id"]},
+            {"id": dataset["name"]},
+        )
+
+        # check org admin of different org cannot edit dataset
+        different_org_admin = factories.User()
+        _ = factories.Organization(
+            users=[{"name": different_org_admin["id"], "capacity": "admin"}]
+        )
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access(
+                "package_update",
+                {"user": different_org_admin["id"]},
+                {"id": dataset["name"]},
+            )
 
     def test_audit_table(self):
         user = factories.User()


### PR DESCRIPTION
PR adds the auth check for `organization_create` and `group_create` to sysadmins only. PR also cleans up the `advancedauth_wrapper_function` by extracting out the auth checks into functions since it was a bit difficult to parse and understand what was going on there. 